### PR TITLE
m_fix : check_line_end until all QM & BT are closed

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -25,27 +25,29 @@ static void	is_qmbt(char *one_ln, char **qmbt)
 
 static int	check_line_end(char **one_ln, char *ln)
 {
-	char	*qmbt;
 	char	*to_free;
-	size_t	i;
+	char	*qmbt;
 	int		cnt;
+	size_t	i;
 
 	to_free = *one_ln;
 	*one_ln = ft_strjoin(*one_ln, ln);
 	free(to_free);
 	is_qmbt(*one_ln, &qmbt);
-	if (qmbt)
+	cnt = 0;
+	i = -1;
+	while (qmbt && ++i < ft_strlen(*one_ln))
 	{
-		cnt = 0;
-		i = -1;
-		while (++i < ft_strlen(*one_ln))
+		if (*(*one_ln + i) == *qmbt)
+			cnt++;
+		if (cnt % 2 == 0 && is_charset(*(*one_ln + i), ";|"))
 		{
-			if (*(*one_ln + i) == *qmbt)
-				cnt++;
+			cnt = 0;
+			is_qmbt(*one_ln + i, &qmbt);
 		}
-		if (cnt % 2)
-			return (0);
 	}
+	if (cnt % 2)
+		return (0);
 	return (1);
 }
 


### PR DESCRIPTION
어제 첨부했던 사진 예시를 보니까
<img width="804" alt="132890803-5659a5d4-08e2-4fc8-b73b-9b801433d5eb" src="https://user-images.githubusercontent.com/83805691/132936187-f650ca1a-b59c-4269-89bf-d28a8f0ce8e6.png">

isn't 에서 나오는 ' 가 열려 있는데 그냥 넘어갔더라고요. 그 부분 수정했습니다.
아직 \' \" \` \\n는 처리 안 됐습니다.