### PR TITLE
m_fix : fix envp pointer, exit keyword

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/09 12:08:34 by ghan              #+#    #+#             */
-/*   Updated: 2021/09/11 16:11:44 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/09/12 09:50:11 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,6 @@ int	main(int argc, char *argv[], char *envp[])
 	char	*one_line;
 	char	**cmds;
 
-	envp = 0;
 	if (argc > 1 || argv[1])
 		is_error(NULL, NULL, "esh does not receive arguments", EXIT_FAILURE);
 	signal(SIGINT, signal_handler);
@@ -50,7 +49,7 @@ int	main(int argc, char *argv[], char *envp[])
 	while (1)
 	{
 		line_read = readline("🐘 esh > ");
-		if (!line_read)
+		if (!line_read || !ft_strncmp(line_read, "exit", 4))
 		{
 			printf("exit\n");
 			exit(EXIT_SUCCESS);

--- a/src/pipe/pipe_main.c
+++ b/src/pipe/pipe_main.c
@@ -6,7 +6,7 @@
 /*   By: jun <yongjule@42student.42seoul.kr>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/10 16:22:10 by jun               #+#    #+#             */
-/*   Updated: 2021/09/11 19:15:53 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/09/12 08:50:11 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,16 +37,6 @@ int	exec_cmd_main(char **cmds, char **envp)
 				args->envp = envp;
 				args->cnt = cmd_cnt;
 				build_structure(&cmds[cmd_start], envp, args);
-//			int cnt = 0 , cnt1 = 0;
-//			while (args->cmd[cnt].params)
-//			{
-//				while (args->cmd[cnt].params[cnt1])
-//				{
-//					printf("%s\n", args->cmd[cnt].params[cnt1]);
-//					cnt1++;
-//				}
-//				cnt++;
-//			}
 				breed_process(args);
 			}
 			waitpid(pid, NULL, 0);


### PR DESCRIPTION
exit을 단순하게 넣긴 했지만, whitespace를 무시하고 나서 strcmp를 해야하기 때문에 정상적이진 않습니다,,,

whitespace를 지우기 위해 strtrim을 써야할텐데 결국 trim이 할당을 받아서 할당 오류가 날 수 있잖아요?

할당을 안하고 exit만 찾는 방법이나, fork를 한 뒤 exit을 입력 받으면 모든 프로세스를 종료시키는 방법이 떠오르는데, fork하는 방법은 exit_status가 꼬일 가능성이 있어 보여서 전자를 생각중입니다

그리고 exit는 ls | exit 이런식으로 사용하면 exit이 안됨니다... 정확히 exit만 들어와야 작동하나봐요