### PR TITLE
m_fix : undo termios setting change

### DIFF
--- a/src/parse/parse_main.c
+++ b/src/parse/parse_main.c
@@ -61,19 +61,19 @@ static int	check_line_end(char **one_ln, char *ln)
 
 static void	internal_prompt_sig_handler(int sig)
 {
-	struct termios	term;
-	int				result;
+	// struct termios	term;
+	// int				result;
 
 	if (sig == SIGINT)
 	{
 		g_exit_code = -42;
-		result = tcgetattr(STDIN_FILENO, &term);
-		if (result < 0)
-			is_error(NULL, NULL, "error in tcgetattr", EXIT_FAILURE);
-		term.c_oflag = ICANON | ECHOE;
-		result = tcsetattr(STDIN_FILENO, TCSANOW, &term);
-		if (result < 0)
-			is_error(NULL, NULL, "error in tcgetattr", EXIT_FAILURE);
+		// result = tcgetattr(STDIN_FILENO, &term);
+		// if (result < 0)
+		// 	is_error(NULL, NULL, "error in tcgetattr", EXIT_FAILURE);
+		// term.c_oflag = ICANON | ECHOE;
+		// result = tcsetattr(STDIN_FILENO, TCSANOW, &term);
+		// if (result < 0)
+		// 	is_error(NULL, NULL, "error in tcgetattr", EXIT_FAILURE);
 		// ft_putchar_fd('\n', STDOUT_FILENO);
 		// close(STDIN_FILENO);
 	}


### PR DESCRIPTION
잘못하면 terminal setting이 영구적으로 바뀌는 것 (default 세팅을 잃어버려서) 같아서 일단 termios 부분 주석처리해놨습니다 ㅋㅋ