### PR TITLE
m_fix : change builtin-cmd prototype type void to int

### DIFF
--- a/include/builtin.h
+++ b/include/builtin.h
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@student.42seoul.kr      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/23 10:31:34 by yongjule          #+#    #+#             */
-/*   Updated: 2021/09/24 14:02:35 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/09/26 09:50:08 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,11 +38,11 @@ typedef enum e_builtin
 int		is_error_no_exit(char *str1, char *str2, char *err_msg, int status);
 
 /*Builtin Commands*/
-void	exprot(const char *path, char *const argv[], char *const envp[]);
-void	echo(const char *path, char *const argv[], char *const envp[]);
-void	ext(const char *path, char *const argv[], char *const envp[]);
-void	cd(const char *path, char *const argv[], char *const envp[]);
-void	pwd(const char *path, char *const argv[], char *const envp[]);
-void	env(const char *path, char *const argv[], char *const envp[]);
+int		exprot(const char *path, char *const argv[], char *const envp[]);
+int		echo(const char *path, char *const argv[], char *const envp[]);
+int		ext(const char *path, char *const argv[], char *const envp[]);
+int		cd(const char *path, char *const argv[], char *const envp[]);
+int		pwd(const char *path, char *const argv[], char *const envp[]);
+int		env(const char *path, char *const argv[], char *const envp[]);
 
 #endif

--- a/src/builtin/chdir.c
+++ b/src/builtin/chdir.c
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@42student.42seoul.      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/24 10:43:34 by yongjule          #+#    #+#             */
-/*   Updated: 2021/09/24 11:32:56 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/09/26 09:50:21 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ static	int	handle_exit_error(char *cmd, char *argument)
 	return (exit_status);
 }
 
-void	cd(const char *path, char *const argv[], char *const envp[])
+int	cd(const char *path, char *const argv[], char *const envp[])
 {
 	char	*home;
 	int		exit_status;
@@ -49,4 +49,5 @@ void	cd(const char *path, char *const argv[], char *const envp[])
 	//	else
 	//		update_env("PWD", argv[1]);
 	g_exit_code = exit_status;
+	return (0);
 }

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -6,13 +6,15 @@
 /*   By: yongjule <yongjule@student.42seoul.kr      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/23 12:53:44 by yongjule          #+#    #+#             */
-/*   Updated: 2021/09/23 13:04:39 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/09/26 09:52:20 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin.h"
 
-void	echo(const char *path, char *const argv[], char *const envp[])
+extern int	g_exit_code;
+
+int	echo(const char *path, char *const argv[], char *const envp[])
 {
 	int	idx;
 	int	flag;
@@ -25,5 +27,6 @@ void	echo(const char *path, char *const argv[], char *const envp[])
 		printf("%s", argv[flag + idx++]);
 	if (!flag)
 		printf("\n");
-	exit(EXIT_SUCCESS);
+	g_exit_code = 0;
+	return (0);
 }

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -6,13 +6,13 @@
 /*   By: ghan <ghan@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/24 13:24:31 by yongjule          #+#    #+#             */
-/*   Updated: 2021/09/25 20:39:00 by ghan             ###   ########.fr       */
+/*   Updated: 2021/09/26 09:50:54 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin.h"
 
-void	env(const char *path, char *const argv[], char *const envp[])
+int	env(const char *path, char *const argv[], char *const envp[])
 {
 	int	idx;
 

--- a/src/builtin/exit.c
+++ b/src/builtin/exit.c
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@student.42seoul.kr      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/23 12:01:16 by yongjule          #+#    #+#             */
-/*   Updated: 2021/09/23 12:55:36 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/09/26 09:51:18 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ static int	check_exit_arg_validity(char **argv)
 **	      without pipe -> do not fork and execute exit
 */
 
-void	ext(const char *path, char *const argv[], char *const envp[])
+int	ext(const char *path, char *const argv[], char *const envp[])
 {
 	extern int	g_exit_code;
 
@@ -52,7 +52,7 @@ void	ext(const char *path, char *const argv[], char *const envp[])
 	{
 		ft_putendl_fd("exit\n 🤣 esh: exit : too many arguments", STDERR_FILENO);
 		g_exit_code = 1;
-		return ;
+		return (-1);
 	}
 	exit(check_exit_arg_validity((char **)argv) & (0xff));
 }

--- a/src/builtin/pwd.c
+++ b/src/builtin/pwd.c
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@42student.42seoul.      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/24 11:24:54 by yongjule          #+#    #+#             */
-/*   Updated: 2021/09/24 13:23:06 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/09/26 09:51:48 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 extern int	g_exit_code;
 
-void	pwd(const char *path, char *const argv[], char *const envp[])
+int	pwd(const char *path, char *const argv[], char *const envp[])
 {
 	if (argv[1])
 	{
@@ -30,5 +30,5 @@ void	pwd(const char *path, char *const argv[], char *const envp[])
 		printf("%s\n", getenv("PWD"));
 		g_exit_code = EXIT_SUCCESS;
 	}
-	exit(g_exit_code);
+	return (g_exit_code);
 }


### PR DESCRIPTION
ㅎㅎ 아무생각 없이 함수 타입을 다 void로 해놨었네요? execve 함수 따라 int로 바꿔뒀습니다.

가능하다면 에러 상황에 대하여 -1 리턴으로 바꿔주세요 ㅎㅎ; exit_code 세팅은 다 해놨던거 같네요 

에러 상황은 시스템적 에러(?),,, 할당 실패나 open 실패같은.. 그런 경우면 되겠네요. 이건 좀 고민되네요. 

근데 ls -Q 같이 없는 옵션을 주고 실행해도 execve가 오류를 뱉는건 아니니 시스템적 에러때만 -1이 좋을것 같아요(자신없음)