### PR TITLE
echo-ing '\n' when there are multiple "-n"s & getcwd error message and pwd update exception handling

### DIFF
--- a/src/builtin/chdir.c
+++ b/src/builtin/chdir.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/24 10:43:34 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/01 20:32:11 by ghan             ###   ########.fr       */
+/*   Updated: 2021/10/02 16:44:13 by ghan             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,11 @@
 
 extern int	g_exit_code;
 
-static void	update_pwd(char ***envp)
+static void	update_pwd(char ***envp, char *arg)
 {
 	char	*cwd;
 	char	*argv_p[3];
+	char	*to_free;
 
 	argv_p[0] = "export";
 	argv_p[1] = ft_strjoin("OLDPWD=", ft_get_envp(*envp, "PWD"));
@@ -25,6 +26,14 @@ static void	update_pwd(char ***envp)
 	exprt("export", argv_p, envp);
 	free(argv_p[1]);
 	cwd = getcwd(NULL, 0);
+	if (!cwd)
+	{
+		to_free = ft_strjoin(ft_get_envp(*envp, "OLDPWD"), "/");
+		cwd = ft_strjoin(to_free, arg);
+		free(to_free);
+		is_error_no_exit("cd: ", "error retrieving current directory: \
+getcwd: ", strerror(errno), EXIT_SUCCESS);
+	}
 	argv_p[1] = ft_strjoin("PWD=", cwd);
 	exprt("export", argv_p, envp);
 	free(argv_p[1]);
@@ -50,7 +59,7 @@ static void	cd_check_error(char *arg, char ***envp)
 					strerror(errno), EXIT_FAILURE);
 	}
 	else
-		update_pwd(envp);
+		update_pwd(envp, arg);
 }
 
 int	cd(const char *path, char *const argv[], char ***const envp)

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/23 12:53:44 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/02 14:35:03 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/02 16:01:47 by ghan             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ int	echo(const char *path, char *const argv[], char *const envp[])
 	while (!ft_strcmp(argv[flag], "-n"))
 		flag++;
 	echo_value(argv, &idx, flag);
-	if (flag != 2)
+	if (flag == 1)
 		ft_putchar_fd('\n', STDOUT_FILENO);
 	return (g_exit_code);
 }


### PR DESCRIPTION
1. `echo -n ... -n` 이렇게 -n 많이 올 때 개행이 안 돼야하는데 개행이 하나씩 들어가고 있어서 조건문 수정해줬습니다.
![Screen Shot 2021-10-02 at 4 02 27 PM](https://user-images.githubusercontent.com/83805691/135708591-ed323db4-cce6-4222-809d-1d62a1092c50.png)
이전상태 ^

2. getcwd errno error msg 세팅, pwd 예외처리 해줬습니다.
<img width="1010" alt="Screen Shot 2021-10-02 at 4 59 02 PM" src="https://user-images.githubusercontent.com/83805691/135708613-b2047b55-7ebf-438e-ad29-68ad74aa8267.png">

![Screen Shot 2021-10-02 at 4 45 53 PM](https://user-images.githubusercontent.com/83805691/135708629-4ad628d9-00df-4d3f-b824-f3691023aed7.png)

![Screen Shot 2021-10-02 at 4 57 38 PM](https://user-images.githubusercontent.com/83805691/135708631-174cc6d8-83d4-4b3b-862f-1d1bc8006074.png)

이 정도 비슷하면 되지 않을까요...?
