### PR TITLE
fix minor bugs and can use other test now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ minishell
 
 #tester
 minishell-tester/
+minishell_tester/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/09/09 15:00:27 by yongjule          #+#    #+#              #
-#    Updated: 2021/10/02 18:32:18 by ghan             ###   ########.fr        #
+#    Updated: 2021/10/03 10:02:40 by yongjule         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -50,6 +50,12 @@ LIBFT_FILE		= $(LIBFT_DIR)libft.a
 
 INC_DIR_MAN		= ./include/
 #INC_DIR_BONUS = ./incs/bonus/
+
+ifdef TEST
+	MAIN = main_to_tester.c
+else
+	MAIN = main.c
+endif
 
 SRCS_BLTIN		= $(addprefix $(SRCS_BLTIN_DIR), \
 				echo.c\
@@ -107,7 +113,7 @@ SRCS_PARSE		= $(addprefix $(SRCS_PARSE_DIR), \
 				)
 
 SRCS_MAN		= $(addprefix $(SRCS_DIR), \
-				main.c\
+				$(MAIN)\
 				utils_main.c\
 				main_signal.c\
 				diy_envp.c\
@@ -213,3 +219,8 @@ leaks			:
 					@make -C $(LIBFT_DIR) LEAKS=1
 					@make LEAKS=1
 					@echo $(CUT)$(RED)$(BOLD) Is there Leaks?🚰$(RESET)
+
+tester			:
+					@make -C $(LIBFT_DIR)
+					@make TEST=1
+					@echo $(CUT)$(RED)$(BOLD) 🥺🙏TESTER🙏🥺 $(RESET)

--- a/src/exec/execute_subshell.c
+++ b/src/exec/execute_subshell.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/11 16:32:50 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/02 20:16:15 by ghan             ###   ########.fr       */
+/*   Updated: 2021/10/03 09:17:10 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,9 @@ static void	execve_error(t_args *args, int idx)
 
 static void	execute_pipe_cmd(t_args *args, int idx)
 {
+	t_builtin	builtin;
+
+	builtin = args->cmd[idx].builtin;
 	sub_env_pipe_cmd(&args, idx);
 	if (args->cnt > idx + 1)
 		connect_pipe_fd(args->cmd[idx].pipe_fd, STDOUT_FILENO);
@@ -64,10 +67,14 @@ static void	execute_pipe_cmd(t_args *args, int idx)
 	if (args->cmd[idx].params && args->cmd[idx].params[0])
 	{
 		sigint_n_sigquit_handler(reset_signal);
-		if (args->cmd[idx].builtin == is_ext)
+		if (builtin == is_ext)
 			delete_output();
-		args->cmd[idx].exec_f.exec(args->cmd[idx].params[0],
-				args->cmd[idx].params, args->envp);
+		if (builtin == is_cd || builtin == is_exprt || builtin == is_unset)
+			args->cmd[idx].exec_f.exec_env(args->cmd[idx].params[0],
+					args->cmd[idx].params, &args->envp);
+		else
+			args->cmd[idx].exec_f.exec(args->cmd[idx].params[0],
+					args->cmd[idx].params, args->envp);
 	}
 	else
 		exit(EXIT_SUCCESS);

--- a/src/main_to_tester.c
+++ b/src/main_to_tester.c
@@ -1,0 +1,70 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   main.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/09/09 12:08:34 by ghan              #+#    #+#             */
+/*   Updated: 2021/10/03 09:46:40 by yongjule         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+int	g_exit_code = 0;
+
+static int	ft_launch_minishell(char *str, char *envp[])
+{
+	char	*line_read;
+	t_cmds	*cmdlst;
+	char	**ft_envp;
+
+	ft_envp = dup_envp(envp, ft_strsetlen(envp));
+	reset_env(&ft_envp);
+	sh_next_level(&ft_envp);
+	if (dup2(STDIN_FILENO, BACKUP_FD) == -1)
+		is_error(NULL, NULL, strerror(errno), EXIT_FAILURE);
+	sigint_n_sigquit_handler(main_sig_handler);
+	line_read = str;
+	unexp_eof_sig_handler();
+	eof_exit(line_read);
+	parse_line_main(&cmdlst, line_read, ft_strdup(""));
+	if (cmdlst && cmdlst->cmd && *cmdlst->cmd)
+		exec_cmd_main(cmdlst, &ft_envp);
+	sigint_n_sigquit_handler(main_sig_handler);
+	free_cmds_lst(&cmdlst);
+	return (g_exit_code);
+}
+
+int	main(int argc, char *argv[], char *envp[])
+{
+	char	*line_read;
+	char	**ft_envp;
+	t_cmds	*cmdlst;
+
+	if (argc >= 3 && !ft_strncmp(argv[1], "-c", 3))
+	{
+		int exit_status = ft_launch_minishell(argv[2], envp);
+		exit(exit_status);
+	}
+	else
+	{
+		while (1)
+		{
+			unexp_eof_sig_handler();
+			rl_outstream = stderr;
+			line_read = readline("🐘 esh > ");
+			eof_exit(line_read);
+			add_history(rl_line_buffer);
+			line_read = argv[2];
+			parse_line_main(&cmdlst, line_read, ft_strdup(""));
+			if (cmdlst && cmdlst->cmd && *cmdlst->cmd)
+				exec_cmd_main(cmdlst, &ft_envp);
+			sigint_n_sigquit_handler(main_sig_handler);
+			free_cmds_lst(&cmdlst);
+			free(line_read);
+		}
+	}
+	return (EXIT_SUCCESS);
+}

--- a/src/main_to_tester.c
+++ b/src/main_to_tester.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   main.c                                             :+:      :+:    :+:   */
+/*   main_to_tester.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/09 12:08:34 by ghan              #+#    #+#             */
-/*   Updated: 2021/10/03 09:46:40 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/03 10:05:05 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ static int	ft_launch_minishell(char *str, char *envp[])
 		exec_cmd_main(cmdlst, &ft_envp);
 	sigint_n_sigquit_handler(main_sig_handler);
 	free_cmds_lst(&cmdlst);
-	return (g_exit_code);
+	exit(g_exit_code);
 }
 
 int	main(int argc, char *argv[], char *envp[])
@@ -44,10 +44,7 @@ int	main(int argc, char *argv[], char *envp[])
 	t_cmds	*cmdlst;
 
 	if (argc >= 3 && !ft_strncmp(argv[1], "-c", 3))
-	{
-		int exit_status = ft_launch_minishell(argv[2], envp);
-		exit(exit_status);
-	}
+		ft_launch_minishell(argv[2], envp);
 	else
 	{
 		while (1)

--- a/src/utils_main.c
+++ b/src/utils_main.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/22 16:37:33 by ghan              #+#    #+#             */
-/*   Updated: 2021/10/02 09:36:14 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/03 10:09:39 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ char	**esh_pre_process(int argc, char *argv[], char *envp[])
 
 	if (argc > 1 || argv[1])
 		is_error(NULL, NULL, "esh does not \
-	receive arguments", EXIT_FAILURE);
+receive arguments", EXIT_FAILURE);
 	ret = dup_envp(envp, ft_strsetlen(envp));
 	reset_env(&ret);
 	sh_next_level(&ret);


### PR DESCRIPTION
파이프로 올때 빌트인 커멘드 함수가 이상하게 연결되어 있더라구요? 고쳤습니다. 그리고 echo 가 파이프로올때 지금 이상한데 수정해보렵니다.

./minishell 이 -c "cmds" 이런식으로 인자를 받을 수 있게 하는 메인을 만들었습니다. 그래서 이제 [테스터](https://github.com/thallard/minishell_tester)를 이용할 수 있습니다. 261/320정도 나오는군요

`make tester` 룰로 컴파일하도록 makefile에 세팅해놨고, 테스터에 `test.sh`를 살짝 수정해야 합니다.

테스터 클론하면 있는 test.sh의 53번째 줄에서
```sh
-		make all -C $PATH_Makefile
+		make -C $PATH_Makefile tester
```
이렇게 수정하면 됩니다.

물론 -c가 잘 먹는지 모르겠으니 틀린 케이스에 대하여 그냥 make해서 테스트한번 더 해보고 판단하면 될 것 같습니다