### PR TITLE
fix cmd which include '/' character

### DIFF
--- a/src/exec/check_validity.c
+++ b/src/exec/check_validity.c
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@student.42seoul.kr      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/11 16:33:20 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/04 14:43:46 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/04 14:45:10 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ static char	*prefix_dir_to_cmd(t_args *args, char *param, int nth_path)
 	char		*tmp_cmd;
 
 	if (ft_strchr(param, '/'))
-		return ft_strdup(param);
+		return (ft_strdup(param));
 	tmpstr = ft_strjoin(args->env_path[nth_path], "/");
 	tmp_cmd = ft_strjoin(tmpstr, param);
 	free(tmpstr);

--- a/src/exec/check_validity.c
+++ b/src/exec/check_validity.c
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@student.42seoul.kr      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/11 16:33:20 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/03 16:07:09 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/04 14:43:46 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ static char	*prefix_dir_to_cmd(t_args *args, char *param, int nth_path)
 	char		*tmpstr;
 	char		*tmp_cmd;
 
+	if (ft_strchr(param, '/'))
+		return ft_strdup(param);
 	tmpstr = ft_strjoin(args->env_path[nth_path], "/");
 	tmp_cmd = ft_strjoin(tmpstr, param);
 	free(tmpstr);

--- a/src/exec/exec_main.c
+++ b/src/exec/exec_main.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/10 16:22:10 by jun               #+#    #+#             */
-/*   Updated: 2021/10/04 14:34:47 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/04 14:45:19 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,6 @@ static void	process_to_execute(t_cmds *cmds, char ***envp, int cmd_cnt)
 	args->cnt = cmd_cnt;
 	args->cmd = (t_cmd *)ft_calloc(args->cnt + 1, sizeof(t_cmd));
 	build_structure(cmds, envp, args);
-//	printf("%s\n", args->cmd[0].params[0]);
 	if (args->cnt == 1 && args->cmd[0].builtin != notbuiltin)
 		execute_builtin(args, envp);
 	else

--- a/src/exec/exec_main.c
+++ b/src/exec/exec_main.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/10 16:22:10 by jun               #+#    #+#             */
-/*   Updated: 2021/10/03 23:48:50 by ghan             ###   ########.fr       */
+/*   Updated: 2021/10/04 14:34:47 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ static void	process_to_execute(t_cmds *cmds, char ***envp, int cmd_cnt)
 	args->cnt = cmd_cnt;
 	args->cmd = (t_cmd *)ft_calloc(args->cnt + 1, sizeof(t_cmd));
 	build_structure(cmds, envp, args);
+//	printf("%s\n", args->cmd[0].params[0]);
 	if (args->cnt == 1 && args->cmd[0].builtin != notbuiltin)
 		execute_builtin(args, envp);
 	else

--- a/src/main_to_tester.c
+++ b/src/main_to_tester.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/09 12:08:34 by ghan              #+#    #+#             */
-/*   Updated: 2021/10/03 11:45:44 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/04 14:26:44 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,6 +48,7 @@ int	main(int argc, char *argv[], char *envp[])
 		ft_launch_minishell(argv[2], envp);
 	else
 	{
+		ft_envp = esh_pre_process(argc, argv, envp);
 		while (1)
 		{
 			unexp_eof_sig_handler();
@@ -55,7 +56,6 @@ int	main(int argc, char *argv[], char *envp[])
 			line_read = readline("🐘 esh > ");
 			eof_exit(line_read);
 			add_history(rl_line_buffer);
-			line_read = argv[2];
 			parse_line_main(&cmdlst, line_read, ft_strdup(""));
 			if (cmdlst && cmdlst->cmd && *cmdlst->cmd)
 				exec_cmd_main(cmdlst, &ft_envp);


### PR DESCRIPTION
파일명에 /가 오지 않는다는 점을 활용하여 커멘드에 / 가 들어있으면 PATH를 연결 안해주는 방식입니다...

그리고 main_to_tester를 살짝 고쳐서 인자가 없을때 저희 미니쉘하고 같은 방식으로 작동합니다(아마도요) 