### PR TITLE
m_fix : no qm backslash parsing

### DIFF
--- a/src/exec/string_utils.c
+++ b/src/exec/string_utils.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/11 16:33:06 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/04 13:23:06 by ghan             ###   ########.fr       */
+/*   Updated: 2021/10/04 14:45:02 by ghan             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,13 +16,16 @@ char	*ft_substr_wo_chr(char *str, unsigned int start, size_t len, char c)
 {
 	size_t	idx;
 	char	*ret;
+	int		flag;
 
+	flag = start;
 	idx = 0;
 	ret = (char *)ft_calloc(len + 1, sizeof(char));
 	while (idx < len)
 	{
 		if (str[start] != c
-			|| (str[start] == c && !is_charset(str[start + 1], "\"\\$")))
+			|| (flag == 1 && str[start] == c
+				&& !is_charset(str[start + 1], "\"\\$")))
 			ret[idx++] = str[start];
 		else if (str[start + 1] == c)
 			ret[idx++] = str[start++ + 1];

--- a/src/redir/rdr_info.c
+++ b/src/redir/rdr_info.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/11 13:23:05 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/02 19:45:02 by ghan             ###   ########.fr       */
+/*   Updated: 2021/10/04 14:41:08 by ghan             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ char	*get_filename(const char *line)
 		file = ft_strdup("");
 	else if (tmp[0] == '\'')
 		file = ft_substr_wo_chr(tmp, 1,
-				get_quote_len(&tmp[1], "'", '\\'), '\\');
+				get_quote_len(&tmp[1], "'", '\0'), '\0');
 	else if (tmp[0] == '"')
 		file = ft_substr_wo_chr(tmp, 1,
 				get_quote_len(&tmp[1], "\"", '\\'), '\\');


### PR DESCRIPTION
qm 없을 때 parse error 고쳤습니다!
![Screen Shot 2021-10-04 at 2 49 58 PM](https://user-images.githubusercontent.com/83805691/135800425-3449932d-812d-4738-b70c-2c855da3821a.png)

이제 `\(space)` 도 bash 처럼 인식해서 `rm (filename)\(space)` 이게 되네요!