### PR TITLE
m_fix : fix &> case

### DIFF
--- a/src/exec/parse_command.c
+++ b/src/exec/parse_command.c
@@ -6,7 +6,7 @@
 /*   By: ghan <ghan@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/11 12:30:42 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/04 18:50:51 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/04 19:19:45 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,8 @@ int	is_rdr(char *str)
 	while (ft_isdigit(*str))
 		str++;
 	if (is_charset(*str, "<>"))
+		return (1);
+	else if (!ft_strncmp(str, "&>", 2))
 		return (1);
 	else
 		return (0);


### PR DESCRIPTION
ㅎㅎ &>를 까먹었네요. 고쳤읍니다. &가 먼저 나오는 리다이렉션은 저거 하나밖에 없으니 뭐,,, 잘 되겠져

그리고 exit code가 2 나오는 경우가 구글링하면 빌트인에서 에러났을때라고 뜨는데 맞는 경우도 있고 아닌 경우도 많더라구요?

좀 테스트 하다 보니 찐 빌트인... 예를들면 export, unset,,,, 미니쉘에는 얘네밖에 없네요. exit는 별도로 관리를 해놨으니. 암튼 얘네는 exit code가 2가 나옵니다.

그리고 바이너리가 존재하는 빌트인 e.g. echo cd env echo 얘네는 exit code 1로 세팅됩니다.

이쯤되면 배쉬가 빌트인 커멘드라 해놓고 바이너리를 쓰는게 아닐까? 의문이 들어서 path를 날려버리고 실행해보니 대부분 실행되긴 합니다 ㅎㅎ
vm이 있다면 sudo rm -rf / 를 해버리고 테스트하면 직빵일텐데.


근데 env는 실행이 안되더라구요? man builtin 보니까 env는 빌트인이 아니네요 ㅡㅡ 42 당신들도 틀렸어