### PR TITLE
fix exit when it executed pipe

### DIFF
--- a/include/exec.h
+++ b/include/exec.h
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/26 14:30:15 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/11 17:24:48 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/12 10:13:41 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -118,6 +118,7 @@ void	no_newline_for_sigquit(int sig);
 /* Check Validity */
 
 void	check_cmd_validity(t_args *args, t_cmd *cmd, char *param);
+t_ll	check_exit_arg_validity(char **argv);
 
 /* Check Builtin */
 

--- a/src/builtin/exit.c
+++ b/src/builtin/exit.c
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/23 12:01:16 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/11 09:37:17 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/12 10:00:41 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,15 +26,16 @@ static t_ll	check_exit_arg_validity(char **argv)
 		idx++;
 	if ((idx > 19 + sign) || argv[1][idx + sign] != '\0')
 	{
-		ft_putstr_fd("exit: ", STDERR_FILENO);
-		is_error(argv[1], ": ", "numeric argument required", EXIT_ERR);
+		ft_putendl_fd("exit", STDERR_FILENO);
+		is_error("exit: ", argv[1], ": numeric argument required", EXIT_ERR);
 	}
 	status = ft_atol(argv[1]);
 	if (ft_strlen(argv[1]) == (19 + sign) && (status == 0 || status == -1))
 	{
-		ft_putstr_fd("exit: ", STDERR_FILENO);
-		is_error(argv[1], ": ", "numeric argument required", EXIT_ERR);
+		ft_putendl_fd("exit", STDERR_FILENO);
+		is_error("exit: ", argv[1], ": numeric argument required", EXIT_ERR);
 	}
+	ft_putendl_fd("exit", STDERR_FILENO);
 	return (status);
 }
 

--- a/src/builtin/exit.c
+++ b/src/builtin/exit.c
@@ -6,13 +6,13 @@
 /*   By: yongjule <yongjule@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/23 12:01:16 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/12 10:00:41 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/12 10:53:48 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin.h"
 
-static t_ll	check_exit_arg_validity(char **argv)
+t_ll	check_exit_arg_validity(char **argv)
 {
 	t_ll	status;
 	size_t	idx;
@@ -25,17 +25,10 @@ static t_ll	check_exit_arg_validity(char **argv)
 	while (ft_isdigit(argv[1][idx + sign]))
 		idx++;
 	if ((idx > 19 + sign) || argv[1][idx + sign] != '\0')
-	{
-		ft_putendl_fd("exit", STDERR_FILENO);
 		is_error("exit: ", argv[1], ": numeric argument required", EXIT_ERR);
-	}
 	status = ft_atol(argv[1]);
 	if (ft_strlen(argv[1]) == (19 + sign) && (status == 0 || status == -1))
-	{
-		ft_putendl_fd("exit", STDERR_FILENO);
 		is_error("exit: ", argv[1], ": numeric argument required", EXIT_ERR);
-	}
-	ft_putendl_fd("exit", STDERR_FILENO);
 	return (status);
 }
 
@@ -46,14 +39,12 @@ int	ext(const char *path, char *const argv[], char *const envp[])
 	if (!path || !argv || !envp)
 	{
 		g_exit_code = is_error_no_exit("export : ", NULL,
-				"pass valid args to builtin functions", EXIT_FAILURE);
+				 "pass valid args to builtin functions", EXIT_FAILURE);
 		return (g_exit_code);
 	}
+	ft_putendl_fd("exit", STDERR_FILENO);
 	if (!argv[1])
-	{
-		ft_putendl_fd("exit", STDERR_FILENO);
 		exit(g_exit_code);
-	}
 	if (ft_strsetlen((char **)argv) > 2)
 	{
 		check_exit_arg_validity((char **)argv);

--- a/src/exec/execute_subshell.c
+++ b/src/exec/execute_subshell.c
@@ -6,7 +6,7 @@
 /*   By: yongjule <yongjule@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/11 16:32:50 by yongjule          #+#    #+#             */
-/*   Updated: 2021/10/10 21:23:34 by yongjule         ###   ########.fr       */
+/*   Updated: 2021/10/12 10:52:52 by yongjule         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,13 @@
 
 extern int	g_exit_code;
 
-static void	delete_output(void)
+static void	delete_output(char **cmd_exit)
 {
 	int	fd;
 
+	check_exit_arg_validity(cmd_exit);
+	if (ft_strsetlen(cmd_exit) > 2)
+		ft_putendl_fd("🤣 esh: exit : too many arguments", STDERR_FILENO);
 	fd = open("/dev/null", O_WRONLY);
 	if (fd < 0)
 		is_error(NULL, NULL, strerror(errno), EXIT_FAILURE);
@@ -79,7 +82,7 @@ static void	execute_pipe_cmd(t_args *args, int idx)
 		error_before_execve(args, idx);
 	sigint_n_sigquit_handler(reset_signal);
 	if (builtin == is_ext)
-		delete_output();
+		delete_output(args->cmd[idx].params);
 	if (builtin == is_cd || builtin == is_exprt || builtin == is_unset)
 		args->cmd[idx].exec_f.exec_env(args->cmd[idx].params[0],
 				args->cmd[idx].params, &args->envp);


### PR DESCRIPTION
파이프로 exit가 올때 output stream을 날려서 exit가 출력이 안되어야 한다고 했잖아여?

근데 exit abc def 이런 유효하지 않은 인자 올때를 생각을 안했더라구요?

그래서 테스트 해보니 ls | exit abc def 이럴때 아무것도 출력이 안되는 현상이 발생하였읍니다. bash는 exit의 에러메시지를 출력하는데 말이죠.

그래서 이 아이들을 수정해줬습니다.

테스터는 변화가 없군요. 너무 못만들었네.